### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/build/android/pylib/android_commands.py
+++ b/build/android/pylib/android_commands.py
@@ -1057,10 +1057,10 @@ class AndroidCommands(object):
       # Otherwise, we want to push any file on the host for which a file with
       # an equivalent MD5 sum does not exist at the same relative path on the
       # device.
-      device_rel = dict([(os.path.relpath(os.path.normpath(t.path),
-                                          real_device_path),
-                          t.hash)
-                         for t in device_hash_tuples])
+      device_rel = {os.path.relpath(os.path.normpath(t.path),
+                                          real_device_path):
+                          t.hash
+                         for t in device_hash_tuples}
       ShouldPush = lambda p, h: p not in device_rel or h != device_rel[p]
 
     return [RelToRealPaths(path) for path, host_hash in host_rel

--- a/build/android/pylib/instrumentation/test_jar.py
+++ b/build/android/pylib/instrumentation/test_jar.py
@@ -206,8 +206,7 @@ class TestJar(object):
       # |available_tests| are in adb instrument format: package.path.class#test.
 
       # Maps a 'class.test' name to each 'package.path.class#test' name.
-      sanitized_test_names = dict([
-          (t.split('.')[-1].replace('#', '.'), t) for t in available_tests])
+      sanitized_test_names = {t.split('.')[-1].replace('#', '.'): t for t in available_tests}
       # Filters 'class.test' names and populates |tests| with the corresponding
       # 'package.path.class#test' names.
       tests = [

--- a/build/android/pylib/utils/json_results_generator_unittest.py
+++ b/build/android/pylib/utils/json_results_generator_unittest.py
@@ -56,7 +56,7 @@ class JSONGeneratorTest(unittest.TestCase):
     PASS_tests = tests_set - (DISABLED_tests | FLAKY_tests | FAILS_tests)
 
     failed_tests = set(failed_tests_list) - DISABLED_tests
-    failed_count_map = dict([(t, 1) for t in failed_tests])
+    failed_count_map = {t: 1 for t in failed_tests}
 
     test_timings = {}
     i = 0
@@ -76,7 +76,7 @@ class JSONGeneratorTest(unittest.TestCase):
         None,   # don't fetch past json results archive
         test_results_map)
 
-    failed_count_map = dict([(t, 1) for t in failed_tests])
+    failed_count_map = {t: 1 for t in failed_tests}
 
     # Test incremental json results
     incremental_json = generator.GetJSON()

--- a/mojo/public/python/mojo_bindings/descriptor.py
+++ b/mojo/public/python/mojo_bindings/descriptor.py
@@ -611,8 +611,8 @@ class MapType(SerializableType):
     if value is None:
       return value
     if isinstance(value, dict):
-      return dict([(self._key_type.Convert(x), self._value_type.Convert(y)) for
-                   x, y in value.iteritems()])
+      return {self._key_type.Convert(x): self._value_type.Convert(y) for
+                   x, y in value.iteritems()}
     raise TypeError('%r is not a dictionary.')
 
   def Serialize(self, value, data_offset, data, handle_offset):

--- a/mojo/public/third_party/jinja2/lexer.py
+++ b/mojo/public/third_party/jinja2/lexer.py
@@ -129,7 +129,7 @@ operators = {
     ';':            TOKEN_SEMICOLON
 }
 
-reverse_operators = dict([(v, k) for k, v in iteritems(operators)])
+reverse_operators = {v: k for k, v in iteritems(operators)}
 assert len(operators) == len(reverse_operators), 'operators dropped'
 operator_re = re.compile('(%s)' % '|'.join(re.escape(x) for x in
                          sorted(operators, key=lambda x: -len(x))))

--- a/mojo/public/tools/bindings/pylib/mojom/parse/translate.py
+++ b/mojo/public/tools/bindings/pylib/mojom/parse/translate.py
@@ -81,8 +81,8 @@ def _AttributeListToDict(attribute_list):
     return None
   assert isinstance(attribute_list, ast.AttributeList)
   # TODO(vtl): Check for duplicate keys here.
-  return dict([(attribute.key, attribute.value)
-                   for attribute in attribute_list])
+  return {attribute.key: attribute.value
+                   for attribute in attribute_list}
 
 def _EnumToDict(enum):
   def EnumValueToDict(enum_value):

--- a/third_party/cython/src/Cython/Compiler/ExprNodes.py
+++ b/third_party/cython/src/Cython/Compiler/ExprNodes.py
@@ -5018,8 +5018,8 @@ class GeneralCallNode(CallNode):
         temps = []
         if len(kwargs.key_value_pairs) > matched_kwargs_count:
             unmatched_args = declared_args[len(args):]
-            keywords = dict([ (arg.key.value, (i+len(pos_args), arg))
-                              for i, arg in enumerate(kwargs.key_value_pairs) ])
+            keywords = {arg.key.value: (i+len(pos_args), arg)
+                              for i, arg in enumerate(kwargs.key_value_pairs)}
             first_missing_keyword = None
             for decl_arg in unmatched_args:
                 name = decl_arg.name

--- a/third_party/cython/src/Cython/Compiler/Nodes.py
+++ b/third_party/cython/src/Cython/Compiler/Nodes.py
@@ -1078,8 +1078,8 @@ class TemplatedTypeNode(CBaseTypeNode):
 
             if sys.version_info[0] < 3:
                 # Py 2.x enforces byte strings as keyword arguments ...
-                options = dict([ (name.encode('ASCII'), value)
-                                 for name, value in options.items() ])
+                options = {name.encode('ASCII'): value
+                                 for name, value in options.items()}
 
             self.type = PyrexTypes.BufferType(base_type, **options)
 

--- a/third_party/cython/src/Cython/Compiler/ParseTreeTransforms.py
+++ b/third_party/cython/src/Cython/Compiler/ParseTreeTransforms.py
@@ -910,7 +910,7 @@ class InterpretCompilerDirectives(CythonTransform, SkipDeclarations):
             if len(args) != 0:
                 raise PostParseError(pos,
                     'The %s directive takes no prepositional arguments' % optname)
-            return optname, dict([(key.value, value) for key, value in kwds.key_value_pairs])
+            return optname, {key.value: value for key, value in kwds.key_value_pairs}
         elif directivetype is list:
             if kwds and len(kwds) != 0:
                 raise PostParseError(pos,

--- a/third_party/cython/src/Cython/Compiler/Tests/TestParseTreeTransforms.py
+++ b/third_party/cython/src/Cython/Compiler/Tests/TestParseTreeTransforms.py
@@ -226,13 +226,12 @@ class TestDebugTransform(DebuggerTestCase):
             L = list(t.find('/Module/Globals'))
             # assertTrue is retarded, use the normal assert statement
             assert L
-            xml_globals = dict(
-                            [(e.attrib['name'], e.attrib['type']) for e in L])
+            xml_globals = {e.attrib['name']: e.attrib['type'] for e in L}
             self.assertEqual(len(L), len(xml_globals))
 
             L = list(t.find('/Module/Functions'))
             assert L
-            xml_funcs = dict([(e.attrib['qualified_name'], e) for e in L])
+            xml_funcs = {e.attrib['qualified_name']: e for e in L}
             self.assertEqual(len(L), len(xml_funcs))
 
             # test globals

--- a/third_party/cython/src/Cython/Compiler/TypeSlots.py
+++ b/third_party/cython/src/Cython/Compiler/TypeSlots.py
@@ -67,8 +67,8 @@ class Signature(object):
         # and are not looked up in here
     }
 
-    type_to_format_map = dict([(type_, format_)
-                                   for format_, type_ in format_map.iteritems()])
+    type_to_format_map = {type_: format_
+                                   for format_, type_ in format_map.iteritems()}
 
     error_value_map = {
         'O': "NULL",

--- a/third_party/cython/src/Cython/Debugger/Tests/TestLibCython.py
+++ b/third_party/cython/src/Cython/Debugger/Tests/TestLibCython.py
@@ -23,7 +23,7 @@ cfuncs_file = os.path.join(root, 'cfuncs.c')
 
 f = open(codefile)
 try:
-    source_to_lineno = dict([ (line.strip(), i + 1) for i, line in enumerate(f) ])
+    source_to_lineno = {line.strip(): i + 1 for i, line in enumerate(f)}
 finally:
     f.close()
 

--- a/third_party/jinja2/lexer.py
+++ b/third_party/jinja2/lexer.py
@@ -129,7 +129,7 @@ operators = {
     ';':            TOKEN_SEMICOLON
 }
 
-reverse_operators = dict([(v, k) for k, v in iteritems(operators)])
+reverse_operators = {v: k for k, v in iteritems(operators)}
 assert len(operators) == len(reverse_operators), 'operators dropped'
 operator_re = re.compile('(%s)' % '|'.join(re.escape(x) for x in
                          sorted(operators, key=lambda x: -len(x))))

--- a/third_party/protobuf/python/google/protobuf/internal/generator_test.py
+++ b/third_party/protobuf/python/google/protobuf/internal/generator_test.py
@@ -114,10 +114,9 @@ class GeneratorTest(unittest.TestCase):
         'default_int32': True,
     }
 
-    has_default_by_name = dict(
-        [(f.name, f.has_default_value)
+    has_default_by_name = {f.name: f.has_default_value
          for f in desc.fields
-         if f.name in expected_has_default_by_name])
+         if f.name in expected_has_default_by_name}
     self.assertEqual(expected_has_default_by_name, has_default_by_name)
 
   def testContainingTypeBehaviorForExtensions(self):

--- a/third_party/protobuf/python/mox.py
+++ b/third_party/protobuf/python/mox.py
@@ -1029,8 +1029,8 @@ class SameElementsAs(Comparator):
     """
 
     try:
-      expected = dict([(element, None) for element in self._expected_seq])
-      actual = dict([(element, None) for element in actual_seq])
+      expected = {element: None for element in self._expected_seq}
+      actual = {element: None for element in actual_seq}
     except TypeError:
       # Fall back to slower list-compare if any of the objects are unhashable.
       expected = list(self._expected_seq)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:mojo?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:mojo?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
