### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/build/android/pylib/android_commands.py
+++ b/build/android/pylib/android_commands.py
@@ -1171,7 +1171,7 @@ class AndroidCommands(object):
     Devices running user builds don't have adb root, but may provide "su" which
     can be used for accessing protected files.
     """
-    return (self._GetProtectedFileCommandRunner() != None)
+    return (self._GetProtectedFileCommandRunner() is not None)
 
   def _GetProtectedFileCommandRunner(self):
     """Finds the best method to access protected files on the device.

--- a/build/android/pylib/device/battery_utils.py
+++ b/build/android/pylib/device/battery_utils.py
@@ -154,8 +154,8 @@ class BatteryUtils(object):
       False otherwise.
     """
     self._DiscoverDeviceProfile()
-    return (self._cache['profile']['enable_command'] != None
-        and self._cache['profile']['charge_counter'] != None)
+    return (self._cache['profile']['enable_command'] is not None
+        and self._cache['profile']['charge_counter'] is not None)
 
   @decorators.WithTimeoutAndRetriesFromInstance()
   def GetFuelGaugeChargeCounter(self, timeout=None, retries=None):

--- a/build/android/pylib/utils/emulator.py
+++ b/build/android/pylib/utils/emulator.py
@@ -410,7 +410,7 @@ class Emulator(object):
         seconds_waited += self._WAITFORDEVICE_TIMEOUT
         device.adb.KillServer()
       self.popen.poll()
-      if self.popen.returncode != None:
+      if self.popen.returncode is not None:
         raise EmulatorLaunchException('EMULATOR DIED')
 
     if seconds_waited >= self._LAUNCH_TIMEOUT:
@@ -427,7 +427,7 @@ class Emulator(object):
     self._DeleteAVD()
     if self.popen:
       self.popen.poll()
-      if self.popen.returncode == None:
+      if self.popen.returncode is None:
         self.popen.kill()
       self.popen = None
 

--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -88,7 +88,7 @@ def MatchesAnyRegexp(flag, list_of_regexps):
   """Returns true if the first argument matches any regular expression in the
   given list."""
   for regexp in list_of_regexps:
-    if regexp.search(flag) != None:
+    if regexp.search(flag) is not None:
       return True
   return False
 
@@ -117,7 +117,7 @@ parser.add_option('--libdir', action='store_true', dest='libdir')
 
 # Make a list of regular expressions to strip out.
 strip_out = []
-if options.strip_out != None:
+if options.strip_out is not None:
   for regexp in options.strip_out:
     strip_out.append(re.compile(regexp))
 

--- a/build/mac/tweak_info_plist.py
+++ b/build/mac/tweak_info_plist.py
@@ -124,7 +124,7 @@ def _DoSCMKeys(plist, add_keys):
 
   # See if the operation failed.
   _RemoveKeys(plist, 'SCMRevision')
-  if scm_revision != None:
+  if scm_revision is not None:
     plist['SCMRevision'] = scm_revision
   elif add_keys:
     print >>sys.stderr, 'Could not determine SCM revision.  This may be OK.'

--- a/build/util/lastchange.py
+++ b/build/util/lastchange.py
@@ -276,7 +276,7 @@ def main(argv=None):
 
   version_info = FetchVersionInfo(opts.default_lastchange, src_dir)
 
-  if version_info.revision == None:
+  if version_info.revision is None:
     version_info.revision = '0'
 
   if opts.revision_only:

--- a/gpu/command_buffer/build_gles2_cmd_buffer.py
+++ b/gpu/command_buffer/build_gles2_cmd_buffer.py
@@ -3824,7 +3824,7 @@ class CHeaderWriter(CWriter):
 
     self.Write(_LICENSE)
     self.Write(_DO_NOT_EDIT_WARNING)
-    if not file_comment == None:
+    if not file_comment is None:
       self.Write(file_comment)
     self.Write("#ifndef %s\n" % self.guard)
     self.Write("#define %s\n\n" % self.guard)
@@ -3853,7 +3853,7 @@ class TypeHandler(object):
   def WriteStruct(self, func, file):
     """Writes a structure that matches the arguments to a function."""
     comment = func.GetInfo('cmd_comment')
-    if not comment == None:
+    if not comment is None:
       file.Write(comment)
     file.Write("struct %s {\n" % func.name)
     file.Write("  typedef %s ValueType;\n" % func.name)
@@ -3862,7 +3862,7 @@ class TypeHandler(object):
     func.WriteCmdFlag(file)
     file.Write("\n")
     result = func.GetInfo('result')
-    if not result == None:
+    if not result is None:
       if len(result) == 1:
         file.Write("  typedef %s Result;\n\n" % result[0])
       else:
@@ -3903,7 +3903,7 @@ class TypeHandler(object):
       file.Write("              \"offset of %s %s should be %d\");\n" %
                  (func.name, arg.name, offset))
       offset += _SIZE_OF_UINT32
-    if not result == None and len(result) > 1:
+    if not result is None and len(result) > 1:
       offset = 0;
       for line in result:
         parts = line.split()
@@ -4176,7 +4176,7 @@ static_assert(offsetof(%(cmd_name)s::Result, %(field_name)s) == %(offset)d,
           gl_arg_strings.append("_")
         gl_func_name = func.GetGLTestFunctionName()
         gl_error_test = ''
-        if not gl_error == None:
+        if not gl_error is None:
           gl_error_test = '\n  EXPECT_EQ(%s, GetGLError());' % gl_error
 
         vars = {
@@ -4266,7 +4266,7 @@ TEST_P(%(test_name)s, %(name)sInvalidArgs%(arg_index)d_%(value_index)d) {
   def WriteGLES2ImplementationDeclaration(self, func, file):
     """Writes the GLES2 Implemention declaration."""
     impl_decl = func.GetInfo('impl_decl')
-    if impl_decl == None or impl_decl == True:
+    if impl_decl is None or impl_decl == True:
       file.Write("%s %s(%s) override;\n" %
                  (func.return_type, func.original_name,
                   func.MakeTypedOriginalArgString("")))
@@ -4333,9 +4333,9 @@ TEST_P(%(test_name)s, %(name)sInvalidArgs%(arg_index)d_%(value_index)d) {
     impl_decl = func.GetInfo('impl_decl')
     gen_cmd = func.GetInfo('gen_cmd')
     if (func.can_auto_generate and
-        (impl_func == None or impl_func == True) and
-        (impl_decl == None or impl_decl == True) and
-        (gen_cmd == None or gen_cmd == True)):
+        (impl_func is None or impl_func == True) and
+        (impl_decl is None or impl_decl == True) and
+        (gen_cmd is None or gen_cmd == True)):
       file.Write("%s GLES2Implementation::%s(%s) {\n" %
                  (func.return_type, func.original_name,
                   func.MakeTypedOriginalArgString("")))
@@ -4378,7 +4378,7 @@ TEST_P(%(test_name)s, %(name)sInvalidArgs%(arg_index)d_%(value_index)d) {
     """Writes the GLES2 Implemention unit test."""
     client_test = func.GetInfo('client_test')
     if (func.can_auto_generate and
-        (client_test == None or client_test == True)):
+        (client_test is None or client_test == True)):
       code = """
 TEST_F(GLES2ImplementationTest, %(name)s) {
   struct Cmds {
@@ -5186,8 +5186,8 @@ TEST_P(%(test_name)s, %(name)sInvalidArgs%(arg_index)d_%(value_index)d) {
     impl_decl = func.GetInfo('impl_decl')
 
     if (func.can_auto_generate and
-          (impl_func == None or impl_func == True) and
-          (impl_decl == None or impl_decl == True)):
+          (impl_func is None or impl_func == True) and
+          (impl_decl is None or impl_decl == True)):
 
       file.Write("%s GLES2Implementation::%s(%s) {\n" %
                  (func.return_type, func.original_name,
@@ -5911,7 +5911,7 @@ TEST_P(%(test_name)s, %(name)sInvalidArgs) {
   def WriteGLES2Implementation(self, func, file):
     """Overrriden from TypeHandler."""
     impl_decl = func.GetInfo('impl_decl')
-    if impl_decl == None or impl_decl == True:
+    if impl_decl is None or impl_decl == True:
       args = {
           'return_type': func.return_type,
           'name': func.original_name,
@@ -6102,7 +6102,7 @@ class GETnHandler(TypeHandler):
   def WriteGLES2Implementation(self, func, file):
     """Overrriden from TypeHandler."""
     impl_decl = func.GetInfo('impl_decl')
-    if impl_decl == None or impl_decl == True:
+    if impl_decl is None or impl_decl == True:
       file.Write("%s GLES2Implementation::%s(%s) {\n" %
                  (func.return_type, func.original_name,
                   func.MakeTypedOriginalArgString("")))
@@ -6447,12 +6447,12 @@ TEST_P(%(test_name)s, %(name)sInvalidArgs%(arg_index)d_%(value_index)d) {
 
   def __NeedsToCalcDataCount(self, func):
     use_count_func = func.GetInfo('use_count_func')
-    return use_count_func != None and use_count_func != False
+    return use_count_func is not None and use_count_func != False
 
   def WriteGLES2Implementation(self, func, file):
     """Overrriden from TypeHandler."""
     impl_func = func.GetInfo('impl_func')
-    if (impl_func != None and impl_func != True):
+    if (impl_func is not None and impl_func != True):
       return;
     file.Write("%s GLES2Implementation::%s(%s) {\n" %
                (func.return_type, func.original_name,
@@ -6481,7 +6481,7 @@ TEST_P(%(test_name)s, %(name)sInvalidArgs%(arg_index)d_%(value_index)d) {
   def WriteGLES2ImplementationUnitTest(self, func, file):
     """Writes the GLES2 Implemention unit test."""
     client_test = func.GetInfo('client_test')
-    if (client_test != None and client_test != True):
+    if (client_test is not None and client_test != True):
       return;
     code = """
 TEST_F(GLES2ImplementationTest, %(name)s) {
@@ -7021,7 +7021,7 @@ class PUTSTRHandler(ArrayArgTypeHandler):
     log_code_block = """  GPU_CLIENT_LOG_CODE_BLOCK({
     for (GLsizei ii = 0; ii < count; ++ii) {
       if (%(data)s[ii]) {"""
-    if length_arg == None:
+    if length_arg is None:
       log_code_block += """
         GPU_CLIENT_LOG("  " << ii << ": ---\\n" << %(data)s[ii] << "\\n---");"""
     else:
@@ -7041,7 +7041,7 @@ class PUTSTRHandler(ArrayArgTypeHandler):
 """
     file.Write(log_code_block % {
           'data': data_arg.name,
-          'length': length_arg.name if not length_arg == None else ''
+          'length': length_arg.name if not length_arg is None else ''
       })
     for arg in func.GetOriginalArgs():
       arg.WriteClientSideValidationCode(file, func)
@@ -7066,7 +7066,7 @@ class PUTSTRHandler(ArrayArgTypeHandler):
 """
     file.Write(code_block % {
         'data': data_arg.name,
-        'length': length_arg.name if not length_arg == None else 'NULL',
+        'length': length_arg.name if not length_arg is None else 'NULL',
         'func_name': func.name,
         'bucket_args': ', '.join(bucket_args),
       })
@@ -7142,7 +7142,7 @@ TEST_F(GLES2ImplementationTest, %(name)s) {
         'bucket_args': ", ".join(bucket_args),
       })
 
-    if self.__GetLengthArg(func) == None:
+    if self.__GetLengthArg(func) is None:
       return
     code = """
 TEST_F(GLES2ImplementationTest, %(name)sWithLength) {
@@ -7562,7 +7562,7 @@ class IsHandler(TypeHandler):
     """Overrriden from TypeHandler."""
     func.AddCmdArg(Argument("result_shm_id", 'uint32_t'))
     func.AddCmdArg(Argument("result_shm_offset", 'uint32_t'))
-    if func.GetInfo('result') == None:
+    if func.GetInfo('result') is None:
       func.AddInfo('result', ['uint32_t'])
 
   def WriteServiceUnitTest(self, func, file, *extras):
@@ -7663,7 +7663,7 @@ TEST_P(%(test_name)s, %(name)sInvalidArgsBadSharedMemoryId) {
   def WriteGLES2Implementation(self, func, file):
     """Overrriden from TypeHandler."""
     impl_func = func.GetInfo('impl_func')
-    if impl_func == None or impl_func == True:
+    if impl_func is None or impl_func == True:
       error_value = func.GetInfo("error_value") or "GL_FALSE"
       file.Write("%s GLES2Implementation::%s(%s) {\n" %
                  (func.return_type, func.original_name,
@@ -7700,7 +7700,7 @@ TEST_P(%(test_name)s, %(name)sInvalidArgsBadSharedMemoryId) {
   def WriteGLES2ImplementationUnitTest(self, func, file):
     """Overrriden from TypeHandler."""
     client_test = func.GetInfo('client_test')
-    if client_test == None or client_test == True:
+    if client_test is None or client_test == True:
       code = """
 TEST_F(GLES2ImplementationTest, %(name)s) {
   struct Cmds {
@@ -7952,7 +7952,7 @@ class Argument(object):
   def GetValidArg(self, func):
     """Gets a valid value for this argument."""
     valid_arg = func.GetValidArg(self)
-    if valid_arg != None:
+    if valid_arg is not None:
       return valid_arg
 
     index = func.GetOriginalArgs().index(self)
@@ -7961,7 +7961,7 @@ class Argument(object):
   def GetValidClientSideArg(self, func):
     """Gets a valid value for this argument."""
     valid_arg = func.GetValidArg(self)
-    if valid_arg != None:
+    if valid_arg is not None:
       return valid_arg
 
     if self.IsPointer():
@@ -7974,7 +7974,7 @@ class Argument(object):
   def GetValidClientSideCmdArg(self, func):
     """Gets a valid value for this argument."""
     valid_arg = func.GetValidArg(self)
-    if valid_arg != None:
+    if valid_arg is not None:
       return valid_arg
     try:
       index = func.GetOriginalArgs().index(self)
@@ -8224,7 +8224,7 @@ class EnumBaseArgument(Argument):
 
   def GetValidArg(self, func):
     valid_arg = func.GetValidArg(self)
-    if valid_arg != None:
+    if valid_arg is not None:
       return valid_arg
     valid = self.named_type.GetValidValues()
     if valid:
@@ -8241,7 +8241,7 @@ class EnumBaseArgument(Argument):
   def GetValidClientSideCmdArg(self, func):
     """Gets a valid value for this argument."""
     valid_arg = func.GetValidArg(self)
-    if valid_arg != None:
+    if valid_arg is not None:
       return valid_arg
 
     valid = self.named_type.GetValidValues()
@@ -8802,7 +8802,7 @@ class Function(object):
 
   def GetGLTestFunctionName(self):
     gl_func_name = self.GetInfo('gl_test_func')
-    if gl_func_name == None:
+    if gl_func_name is None:
       gl_func_name = self.GetGLFunctionName()
     if gl_func_name.startswith("gl"):
       gl_func_name = gl_func_name[2:]
@@ -9412,7 +9412,7 @@ class GLGenerator(object):
         #    self.Log("%s uses bare GLenum %s." % (func_name, arg.name))
 
         gen_cmd = f.GetInfo('gen_cmd')
-        if gen_cmd == True or gen_cmd == None:
+        if gen_cmd == True or gen_cmd is None:
           if f.type_handler.NeedsDataTransferFunction(f):
             methods = f.GetDataTransferMethods()
             if 'immediate' in methods:

--- a/gpu/gles2_conform_support/generate_gles2_embedded_data.py
+++ b/gpu/gles2_conform_support/generate_gles2_embedded_data.py
@@ -30,7 +30,7 @@ class GenerateEmbeddedFiles(object):
     self.scan_dir = scan_dir
     self.base_dir = base_dir
     self.count = 0;
-    if self.base_dir != None:
+    if self.base_dir is not None:
       self.files_data_h = open(os.path.join(base_dir, "FilesDATA.h"), "wb")
       self.files_data_c = open(os.path.join(base_dir, "FilesDATA.c"), "wb")
       self.files_toc_c = open(os.path.join(base_dir, "FilesTOC.c"), "wb")
@@ -46,7 +46,7 @@ class GenerateEmbeddedFiles(object):
 
     self.AddFiles(scan_dir)
 
-    if self.base_dir != None:
+    if self.base_dir is not None:
       self.files_toc_c.write("\n};\n\n");
       self.files_toc_c.write(
         "int numFileEntrys = sizeof(files) / sizeof(struct FileEntry);\n");
@@ -69,7 +69,7 @@ class GenerateEmbeddedFiles(object):
         if not file in GenerateEmbeddedFiles.paths_to_ignore:
           sub_dirs.append(full_path)
       elif ext in GenerateEmbeddedFiles.extensions_to_include:
-        if self.base_dir == None:
+        if self.base_dir is None:
           print full_path.replace("\\", "/")
         else:
           self.count += 1

--- a/mojo/dart/tools/release/rev_pub_package.py
+++ b/mojo/dart/tools/release/rev_pub_package.py
@@ -88,7 +88,7 @@ def build_package_map():
 
 
 def print_package_map(package_map):
-  if (package_map == None) or (len(package_map) == 0):
+  if (package_map is None) or (len(package_map) == 0):
     print('No packages found in %s' % PACKAGES_DIR)
     return
 
@@ -113,7 +113,7 @@ def main():
     # Validate packages passed on command line before operating on any package.
     for package in args.packages:
       package_dir = package_map.get(package)
-      if package_dir == None:
+      if package_dir is None:
           print('ERROR: Do not know package %s' % package)
           print_package_map(package_map)
           return 1
@@ -121,7 +121,7 @@ def main():
     # Now update packages.
     for package in args.packages:
         package_dir = package_map.get(package)
-        assert(package_dir != None)
+        assert(package_dir is not None)
         pubspec = os.path.join(package_dir, 'pubspec.yaml')
         changelog = os.path.join(package_dir, 'CHANGELOG.md')
         new_version = update_pubspec(pubspec)

--- a/mojo/dart/tools/release/rev_sdk.py
+++ b/mojo/dart/tools/release/rev_sdk.py
@@ -63,13 +63,13 @@ def update_pubspec_dependency(pubspec, leaf_package, new_version):
     with open(pubspec, 'r') as stream:
         spec = yaml.load(stream)
         dependencies = spec['dependencies']
-        assert(dependencies != None)
+        assert(dependencies is not None)
         # Extract the version we currently depend on.
         version = dependencies.get(leaf_package)
         # Handle the case where leaf_package is new or missing from the pubspec.
-        if version == None:
+        if version is None:
             version = ''
-        assert(version != None)
+        assert(version is not None)
         # Update the version to the latest.
         dependencies[leaf_package] = new_version
         if version == new_version:
@@ -104,7 +104,7 @@ def main():
     package_map = build_leaf_package_map(leaf_packages)
     for leaf_package in package_map:
         leaf_package_dir = package_map[leaf_package]
-        assert(leaf_package_dir != None)
+        assert(leaf_package_dir is not None)
         leaf_package_pubspec = os.path.join(leaf_package_dir, 'pubspec.yaml')
         # Get current the version number for leaf_package.
         leaf_package_version = get_pubspec_version(leaf_package_pubspec)

--- a/mojo/devtools/common/android_gdb/session.py
+++ b/mojo/devtools/common/android_gdb/session.py
@@ -81,7 +81,7 @@ class DebugSession(object):
     self._adb = adb
     self._remote_file_cache = os.path.join(os.getenv('HOME'), '.mojosymbols')
 
-    if pyelftools_dir != None:
+    if pyelftools_dir is not None:
       sys.path.append(pyelftools_dir)
     try:
       import elftools.elf.elffile as elffile
@@ -109,7 +109,7 @@ class DebugSession(object):
     self.stop()
 
   def stop(self, _unused_return_value=None):
-    if self._remote_file_reader_process != None:
+    if self._remote_file_reader_process is not None:
       self._remote_file_reader_process.kill()
 
   def _find_libraries(self, lib_dirs):

--- a/mojo/public/third_party/ply/yacc.py
+++ b/mojo/public/third_party/ply/yacc.py
@@ -486,7 +486,7 @@ class LRParser:
                     # --! DEBUG
                     return result
 
-            if t == None:
+            if t is None:
 
                 # --! DEBUG
                 debug.error('Error  : %s',
@@ -764,7 +764,7 @@ class LRParser:
                     n = symstack[-1]
                     return getattr(n,"value",None)
 
-            if t == None:
+            if t is None:
 
                 # We have some kind of parsing error here.  To handle
                 # this, we are going to push the current token onto
@@ -1019,7 +1019,7 @@ class LRParser:
                     n = symstack[-1]
                     return getattr(n,"value",None)
 
-            if t == None:
+            if t is None:
 
                 # We have some kind of parsing error here.  To handle
                 # this, we are going to push the current token onto

--- a/mojo/public/tools/bindings/pylib/mojom/generate/generator.py
+++ b/mojo/public/tools/bindings/pylib/mojom/generate/generator.py
@@ -49,7 +49,7 @@ class Generator(object):
     for interface in self.module.interfaces:
       for method in interface.methods:
         result.append(self._GetStructFromMethod(method))
-        if method.response_parameters != None:
+        if method.response_parameters is not None:
           result.append(self._GetResponseStructFromMethod(method))
     return result
 

--- a/mojo/public/tools/bindings/pylib/mojom/generate/module.py
+++ b/mojo/public/tools/bindings/pylib/mojom/generate/module.py
@@ -354,7 +354,7 @@ class Method(object):
 
   def AddResponseParameter(self, name, kind, ordinal=None, default=None,
                            attributes=None):
-    if self.response_parameters == None:
+    if self.response_parameters is None:
       self.response_parameters = []
     parameter = Parameter(name, kind, ordinal, default, attributes)
     self.response_parameters.append(parameter)
@@ -635,6 +635,6 @@ def IsCloneableKind(kind):
 
 def HasCallbacks(interface):
   for method in interface.methods:
-    if method.response_parameters != None:
+    if method.response_parameters is not None:
       return True
   return False

--- a/mojo/public/tools/bindings/pylib/mojom/generate/mojom_translator.py
+++ b/mojo/public/tools/bindings/pylib/mojom/generate/mojom_translator.py
@@ -342,7 +342,7 @@ class FileTranslator(object):
     module_type.attributes = self.AttributesFromMojom(mojom)
     module_type.name = mojom.decl_data.short_name
     module_type.spec = mojom.decl_data.full_identifier
-    if module_type.spec == None:
+    if module_type.spec is None:
       module_type.spec = mojom.decl_data.short_name
     self.PopulateModuleOrImportedFrom(module_type, mojom)
 
@@ -777,7 +777,7 @@ class FileTranslator(object):
     module_type_class, from_mojom = user_defined_types[mojom_type.tag]
     module_type = module_type_class()
 
-    if module_type.spec == None:
+    if module_type.spec is None:
       # module.py expects the spec of user defined types to be set when
       # constructing map, array, and interface request types, but the value
       # appears to be only used for error messages.

--- a/mojo/public/tools/mojom_fetcher/pylib/fetcher/dependency.py
+++ b/mojo/public/tools/mojom_fetcher/pylib/fetcher/dependency.py
@@ -150,12 +150,12 @@ class Dependency(object):
       dep_mojom_path = os.path.join(
           import_dir_candidate, self.get_imported())
       if self._os_path_exists(dep_mojom_path):
-        if result != None:
+        if result is not None:
           raise DuplicateDependencyFoundException(self.get_imported())
         import_dir = os.path.relpath(import_dir_candidate, directory)
         result = (target_from_path(os.path.relpath(
             dep_mojom_path, directory)), import_dir)
-    if result == None:
+    if result is None:
       raise DependencyNotFoundException(self.get_imported())
     return result
 

--- a/mojo/public/tools/mojom_fetcher/pylib/fetcher/mojom_file.py
+++ b/mojo/public/tools/mojom_fetcher/pylib/fetcher/mojom_file.py
@@ -36,7 +36,7 @@ class MojomFile(object):
         params["mojo_sdk_deps"].append(target)
       else:
         target, import_dir = dep.get_target_and_import(include_dirs)
-        if import_dir != None:
+        if import_dir is not None:
             params["import_dirs"].add(import_dir)
         params["deps"].append(target)
 

--- a/third_party/cython/src/Cython/Debugger/libpython.py
+++ b/third_party/cython/src/Cython/Debugger/libpython.py
@@ -1390,7 +1390,7 @@ that this python file is installed to the same path as the library (or its
   /usr/lib/debug/usr/lib/libpython2.6.so.1.0.debug-gdb.py
 """
 def register (obj):
-    if obj == None:
+    if obj is None:
         obj = gdb
 
     # Wire up the pretty-printer

--- a/third_party/freetype2/src/src/tools/chktrcmp.py
+++ b/third_party/freetype2/src/src/tools/chktrcmp.py
@@ -55,14 +55,14 @@ trace_use_pat  = re.compile( '^[ \t]*#define[ \t]+FT_COMPONENT[ \t]+trace_' )
 for d in SRC_FILE_DIRS:
   for ( p, dlst, flst ) in os.walk( d ):
     for f in flst:
-      if c_pathname_pat.match( f ) != None:
+      if c_pathname_pat.match( f ) is not None:
         src_pathname = os.path.join( p, f )
 
         line_num = 0
         for src_line in open( src_pathname, 'r' ):
           line_num = line_num + 1
           src_line = src_line.strip()
-          if trace_use_pat.match( src_line ) != None:
+          if trace_use_pat.match( src_line ) is not None:
             component_name = trace_use_pat.sub( '', src_line )
             if component_name in USED_COMPONENT:
               USED_COMPONENT[component_name].append( "%s:%d" % ( src_pathname, line_num ) )
@@ -82,7 +82,7 @@ for f in TRACE_DEF_FILES:
   for hdr_line in open( f, 'r' ):
     line_num = line_num + 1
     hdr_line = hdr_line.strip()
-    if trace_def_pat_opn.match( hdr_line ) != None:
+    if trace_def_pat_opn.match( hdr_line ) is not None:
       component_name = trace_def_pat_opn.sub( '', hdr_line )
       component_name = trace_def_pat_cls.sub( '', component_name )
       if component_name in KNOWN_COMPONENT:

--- a/third_party/freetype2/src/src/tools/docmaker/sources.py
+++ b/third_party/freetype2/src/src/tools/docmaker/sources.py
@@ -268,7 +268,7 @@ class  SourceBlock:
         self.format    = processor.format
         self.content   = []
 
-        if self.format == None:
+        if self.format is None:
             return
 
         words = []
@@ -356,7 +356,7 @@ class  SourceProcessor:
             if line[-1] == '\012':
                 line = line[0:-1]
 
-            if self.format == None:
+            if self.format is None:
                 self.process_normal_line( line )
             else:
                 if self.format.end.match( line ):

--- a/third_party/freetype2/src/src/tools/docmaker/tohtml.py
+++ b/third_party/freetype2/src/src/tools/docmaker/tohtml.py
@@ -308,7 +308,7 @@ class  HtmlFormatter( Formatter ):
         return self.file_prefix + section.name + ".html"
 
     def  make_block_url( self, block, name = None ):
-        if name == None:
+        if name is None:
             name = block.name
 
         try:
@@ -544,7 +544,7 @@ class  HtmlFormatter( Formatter ):
         self.index_items = {}
 
     def  index_dump( self, index_filename = None ):
-        if index_filename == None:
+        if index_filename is None:
             index_filename = self.file_prefix + "index.html"
 
         Formatter.index_dump( self, index_filename )
@@ -586,10 +586,10 @@ class  HtmlFormatter( Formatter ):
         print self.html_footer
 
     def  toc_dump( self, toc_filename = None, index_filename = None ):
-        if toc_filename == None:
+        if toc_filename is None:
             toc_filename = self.file_prefix + "toc.html"
 
-        if index_filename == None:
+        if index_filename is None:
             index_filename = self.file_prefix + "index.html"
 
         Formatter.toc_dump( self, toc_filename, index_filename )

--- a/third_party/libxml/src/check-relaxng-test-suite.py
+++ b/third_party/libxml/src/check-relaxng-test-suite.py
@@ -74,7 +74,7 @@ def handle_valid(node, schema):
 
     instance = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
 	child = child.next
@@ -84,7 +84,7 @@ def handle_valid(node, schema):
     except:
         doc = None
 
-    if doc == None:
+    if doc is None:
         log.write("\nFailed to parse correct instance:\n-----\n")
 	log.write(instance)
         log.write("\n-----\n")
@@ -115,7 +115,7 @@ def handle_invalid(node, schema):
 
     instance = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
 	child = child.next
@@ -125,7 +125,7 @@ def handle_invalid(node, schema):
     except:
         doc = None
 
-    if doc == None:
+    if doc is None:
         log.write("\nStrange: failed to parse incorrect instance:\n-----\n")
 	log.write(instance)
         log.write("\n-----\n")
@@ -155,7 +155,7 @@ def handle_correct(node):
 
     schema = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
 	child = child.next
@@ -165,7 +165,7 @@ def handle_correct(node):
 	rngs = rngp.relaxNGParse()
     except:
         rngs = None
-    if rngs == None:
+    if rngs is None:
         log.write("\nFailed to compile correct schema:\n-----\n")
 	log.write(schema)
         log.write("\n-----\n")
@@ -181,7 +181,7 @@ def handle_incorrect(node):
 
     schema = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
 	child = child.next
@@ -191,7 +191,7 @@ def handle_incorrect(node):
 	rngs = rngp.relaxNGParse()
     except:
         rngs = None
-    if rngs != None:
+    if rngs is not None:
         log.write("\nFailed to detect schema error in:\n-----\n")
 	log.write(schema)
         log.write("\n-----\n")
@@ -214,17 +214,17 @@ def handle_resource(node, dir):
     except:
         name = None
 
-    if name == None or name == '':
+    if name is None or name == '':
         log.write("resource has no name")
 	return;
         
-    if dir != None:
+    if dir is not None:
 #        name = libxml2.buildURI(name, dir)
         name = dir + '/' + name
 
     res = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    res = res + child.serialize()
 	child = child.next
@@ -239,11 +239,11 @@ def handle_dir(node, dir):
     except:
         name = None
 
-    if name == None or name == '':
+    if name is None or name == '':
         log.write("resource has no name")
 	return;
         
-    if dir != None:
+    if dir is not None:
 #        name = libxml2.buildURI(name, dir)
         name = dir + '/' + name
 
@@ -296,7 +296,7 @@ def handle_testCase(node):
     valids = node.xpathEval('valid')
     invalids = node.xpathEval('invalid')
     nb_instances_tests = nb_instances_tests + len(valids) + len(invalids)
-    if schema != None:
+    if schema is not None:
         for valid in valids:
 	    handle_valid(valid, schema)
         for invalid in invalids:

--- a/third_party/libxml/src/check-relaxng-test-suite2.py
+++ b/third_party/libxml/src/check-relaxng-test-suite2.py
@@ -60,10 +60,10 @@ def handle_valid(node, schema):
     global nb_instances_failed
 
     instance = node.prop("dtd")
-    if instance == None:
+    if instance is None:
         instance = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
 	child = child.next
@@ -74,7 +74,7 @@ def handle_valid(node, schema):
     except:
         doc = None
 
-    if doc == None:
+    if doc is None:
         log.write("\nFailed to parse correct instance:\n-----\n")
 	log.write(instance)
         log.write("\n-----\n")
@@ -113,10 +113,10 @@ def handle_invalid(node, schema):
     global nb_instances_failed
 
     instance = node.prop("dtd")
-    if instance == None:
+    if instance is None:
         instance = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
 	child = child.next
@@ -128,7 +128,7 @@ def handle_invalid(node, schema):
     except:
         doc = None
 
-    if doc == None:
+    if doc is None:
         log.write("\nStrange: failed to parse incorrect instance:\n-----\n")
 	log.write(instance)
         log.write("\n-----\n")
@@ -169,7 +169,7 @@ def handle_correct(node):
 
     schema = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
 	child = child.next
@@ -179,7 +179,7 @@ def handle_correct(node):
 	rngs = rngp.relaxNGParse()
     except:
         rngs = None
-    if rngs == None:
+    if rngs is None:
         log.write("\nFailed to compile correct schema:\n-----\n")
 	log.write(schema)
         log.write("\n-----\n")
@@ -195,7 +195,7 @@ def handle_incorrect(node):
 
     schema = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
 	child = child.next
@@ -205,7 +205,7 @@ def handle_incorrect(node):
 	rngs = rngp.relaxNGParse()
     except:
         rngs = None
-    if rngs != None:
+    if rngs is not None:
         log.write("\nFailed to detect schema error in:\n-----\n")
 	log.write(schema)
         log.write("\n-----\n")
@@ -228,17 +228,17 @@ def handle_resource(node, dir):
     except:
         name = None
 
-    if name == None or name == '':
+    if name is None or name == '':
         log.write("resource has no name")
 	return;
         
-    if dir != None:
+    if dir is not None:
 #        name = libxml2.buildURI(name, dir)
         name = dir + '/' + name
 
     res = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    res = res + child.serialize()
 	child = child.next
@@ -253,11 +253,11 @@ def handle_dir(node, dir):
     except:
         name = None
 
-    if name == None or name == '':
+    if name is None or name == '':
         log.write("resource has no name")
 	return;
         
-    if dir != None:
+    if dir is not None:
 #        name = libxml2.buildURI(name, dir)
         name = dir + '/' + name
 
@@ -310,7 +310,7 @@ def handle_testCase(node):
     valids = node.xpathEval('valid')
     invalids = node.xpathEval('invalid')
     nb_instances_tests = nb_instances_tests + len(valids) + len(invalids)
-    if schema != None:
+    if schema is not None:
         for valid in valids:
 	    handle_valid(valid, schema)
         for invalid in invalids:

--- a/third_party/libxml/src/check-xinclude-test-suite.py
+++ b/third_party/libxml/src/check-xinclude-test-suite.py
@@ -64,16 +64,16 @@ def runTest(test, basedir):
     uri = test.prop('href')
     id = test.prop('id')
     type = test.prop('type')
-    if uri == None:
+    if uri is None:
         print "Test without ID:", uri
 	return -1
-    if id == None:
+    if id is None:
         print "Test without URI:", id
 	return -1
-    if type == None:
+    if type is None:
         print "Test without URI:", id
 	return -1
-    if basedir != None:
+    if basedir is not None:
 	URI = basedir + "/" + uri
     else:
         URI = uri
@@ -90,8 +90,8 @@ def runTest(test, basedir):
 	    output = None
 	if output == '':
 	    output = None
-	if output != None:
-	    if basedir != None:
+	if output is not None:
+	    if basedir is not None:
 		output = basedir + "/" + output
 	    if os.access(output, os.R_OK) == 0:
 		print "Result for %s missing: %s" % (id, output)
@@ -109,9 +109,9 @@ def runTest(test, basedir):
 	doc = libxml2.parseFile(URI)
     except:
         doc = None
-    if doc != None:
+    if doc is not None:
         res = doc.xincludeProcess()
-	if res >= 0 and expected != None:
+	if res >= 0 and expected is not None:
 	    result = doc.serialize()
 	    if result != expected:
 	        print "Result for %s differs" % (id)
@@ -162,7 +162,7 @@ def runTest(test, basedir):
 	    log.write("   ----\n%s   ----\n" % (error_msg))
 	    error_msg = ''
 	log.write("\n")
-    if diff != None:
+    if diff is not None:
         log.write("diff from test %s:\n" %(id))
 	log.write("   -----------\n%s\n   -----------\n" % (diff));
 
@@ -171,14 +171,14 @@ def runTest(test, basedir):
 
 def runTestCases(case):
     creator = case.prop('creator')
-    if creator != None:
+    if creator is not None:
 	print "=>", creator
     base = case.getBase(None)
     basedir = case.prop('basedir')
-    if basedir != None:
+    if basedir is not None:
 	base = libxml2.buildURI(basedir, base)
     test = case.children
-    while test != None:
+    while test is not None:
         if test.name == 'testcase':
 	    runTest(test, base)
 	if test.name == 'testcases':
@@ -186,7 +186,7 @@ def runTestCases(case):
         test = test.next
         
 conf = libxml2.parseFile(CONF)
-if conf == None:
+if conf is None:
     print "Unable to load %s" % CONF
     sys.exit(1)
 
@@ -196,13 +196,13 @@ if testsuite.name != 'testsuite':
     sys.exit(1)
 
 profile = testsuite.prop('PROFILE')
-if profile != None:
+if profile is not None:
     print profile
 
 start = time.time()
 
 case = testsuite.children
-while case != None:
+while case is not None:
     if case.name == 'testcases':
 	old_test_nr = test_nr
 	old_test_succeed = test_succeed

--- a/third_party/libxml/src/check-xml-test-suite.py
+++ b/third_party/libxml/src/check-xml-test-suite.py
@@ -53,7 +53,7 @@ libxml2.registerErrorHandler(errorHandler, None)
 #
 def loadNoentDoc(filename):
     ctxt = libxml2.createFileParserCtxt(filename)
-    if ctxt == None:
+    if ctxt is None:
         return None
     ctxt.replaceEntities(1)
     ctxt.parseDocument()
@@ -79,7 +79,7 @@ def testNotWf(filename, id):
     error_msg = ''
 
     ctxt = libxml2.createFileParserCtxt(filename)
-    if ctxt == None:
+    if ctxt is None:
         return -1
     ret = ctxt.parseDocument()
 
@@ -87,7 +87,7 @@ def testNotWf(filename, id):
 	doc = ctxt.doc()
     except:
         doc = None
-    if doc != None:
+    if doc is not None:
 	doc.freeDoc()
     if ret == 0 or ctxt.wellFormed() != 0:
         print "%s: error: Well Formedness error not detected" % (id)
@@ -104,7 +104,7 @@ def testNotWfEnt(filename, id):
     error_msg = ''
 
     ctxt = libxml2.createFileParserCtxt(filename)
-    if ctxt == None:
+    if ctxt is None:
         return -1
     ctxt.replaceEntities(1)
     ret = ctxt.parseDocument()
@@ -113,7 +113,7 @@ def testNotWfEnt(filename, id):
 	doc = ctxt.doc()
     except:
         doc = None
-    if doc != None:
+    if doc is not None:
 	doc.freeDoc()
     if ret == 0 or ctxt.wellFormed() != 0:
         print "%s: error: Well Formedness error not detected" % (id)
@@ -130,7 +130,7 @@ def testNotWfEntDtd(filename, id):
     error_msg = ''
 
     ctxt = libxml2.createFileParserCtxt(filename)
-    if ctxt == None:
+    if ctxt is None:
         return -1
     ctxt.replaceEntities(1)
     ctxt.loadSubset(1)
@@ -140,7 +140,7 @@ def testNotWfEntDtd(filename, id):
 	doc = ctxt.doc()
     except:
         doc = None
-    if doc != None:
+    if doc is not None:
 	doc.freeDoc()
     if ret == 0 or ctxt.wellFormed() != 0:
         print "%s: error: Well Formedness error not detected" % (id)
@@ -157,7 +157,7 @@ def testWfEntDtd(filename, id):
     error_msg = ''
 
     ctxt = libxml2.createFileParserCtxt(filename)
-    if ctxt == None:
+    if ctxt is None:
         return -1
     ctxt.replaceEntities(1)
     ctxt.loadSubset(1)
@@ -167,10 +167,10 @@ def testWfEntDtd(filename, id):
 	doc = ctxt.doc()
     except:
         doc = None
-    if doc == None or ret != 0 or ctxt.wellFormed() == 0:
+    if doc is None or ret != 0 or ctxt.wellFormed() == 0:
         print "%s: error: wrongly failed to parse the document" % (id)
 	log.write("%s: error: wrongly failed to parse the document\n" % (id))
-	if doc != None:
+	if doc is not None:
 	    doc.freeDoc()
 	return 0
     if error_nr != 0:
@@ -190,7 +190,7 @@ def testError(filename, id):
     error_msg = ''
 
     ctxt = libxml2.createFileParserCtxt(filename)
-    if ctxt == None:
+    if ctxt is None:
         return -1
     ctxt.replaceEntities(1)
     ctxt.loadSubset(1)
@@ -200,7 +200,7 @@ def testError(filename, id):
 	doc = ctxt.doc()
     except:
         doc = None
-    if doc != None:
+    if doc is not None:
 	doc.freeDoc()
     if ctxt.wellFormed() == 0:
         print "%s: warning: failed to parse the document but accepted" % (id)
@@ -221,7 +221,7 @@ def testInvalid(filename, id):
     error_msg = ''
 
     ctxt = libxml2.createFileParserCtxt(filename)
-    if ctxt == None:
+    if ctxt is None:
         return -1
     ctxt.validate(1)
     ret = ctxt.parseDocument()
@@ -231,7 +231,7 @@ def testInvalid(filename, id):
     except:
         doc = None
     valid = ctxt.isValid()
-    if doc == None:
+    if doc is None:
         print "%s: error: wrongly failed to parse the document" % (id)
 	log.write("%s: error: wrongly failed to parse the document\n" % (id))
 	return 0
@@ -257,7 +257,7 @@ def testValid(filename, id):
     error_msg = ''
 
     ctxt = libxml2.createFileParserCtxt(filename)
-    if ctxt == None:
+    if ctxt is None:
         return -1
     ctxt.validate(1)
     ctxt.parseDocument()
@@ -267,7 +267,7 @@ def testValid(filename, id):
     except:
         doc = None
     valid = ctxt.isValid()
-    if doc == None:
+    if doc is None:
         print "%s: error: wrongly failed to parse the document" % (id)
 	log.write("%s: error: wrongly failed to parse the document\n" % (id))
 	return 0
@@ -293,10 +293,10 @@ def runTest(test):
 
     uri = test.prop('URI')
     id = test.prop('ID')
-    if uri == None:
+    if uri is None:
         print "Test without ID:", uri
 	return -1
-    if id == None:
+    if id is None:
         print "Test without URI:", id
 	return -1
     base = test.getBase(None)
@@ -305,7 +305,7 @@ def runTest(test):
         print "Test %s missing: base %s uri %s" % (URI, base, uri)
 	return -1
     type = test.prop('TYPE')
-    if type == None:
+    if type is None:
         print "Test %s missing TYPE" % (id)
 	return -1
 
@@ -348,7 +348,7 @@ def runTest(test):
 	content = string.strip(test.content)
 	while content[-1] == '\n':
 	    content = content[0:-1]
-	if extra != None:
+	if extra is not None:
 	    log.write("   %s:%s:%s\n" % (type, extra, content))
 	else:
 	    log.write("   %s:%s\n\n" % (type, content))
@@ -362,11 +362,11 @@ def runTest(test):
 
 def runTestCases(case):
     profile = case.prop('PROFILE')
-    if profile != None and \
+    if profile is not None and \
        string.find(profile, "IBM XML Conformance Test Suite - Production") < 0:
 	print "=>", profile
     test = case.children
-    while test != None:
+    while test is not None:
         if test.name == 'TEST':
 	    runTest(test)
 	if test.name == 'TESTCASES':
@@ -374,7 +374,7 @@ def runTestCases(case):
         test = test.next
         
 conf = loadNoentDoc(CONF)
-if conf == None:
+if conf is None:
     print "Unable to load %s" % CONF
     sys.exit(1)
 
@@ -384,13 +384,13 @@ if testsuite.name != 'TESTSUITE':
     sys.exit(1)
 
 profile = testsuite.prop('PROFILE')
-if profile != None:
+if profile is not None:
     print profile
 
 start = time.time()
 
 case = testsuite.children
-while case != None:
+while case is not None:
     if case.name == 'TESTCASES':
 	old_test_nr = test_nr
 	old_test_succeed = test_succeed

--- a/third_party/libxml/src/check-xsddata-test-suite.py
+++ b/third_party/libxml/src/check-xsddata-test-suite.py
@@ -59,10 +59,10 @@ def handle_valid(node, schema):
     global nb_instances_failed
 
     instance = node.prop("dtd")
-    if instance == None:
+    if instance is None:
         instance = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
 	child = child.next
@@ -73,7 +73,7 @@ def handle_valid(node, schema):
     except:
         doc = None
 
-    if doc == None:
+    if doc is None:
         log.write("\nFailed to parse correct instance:\n-----\n")
 	log.write(instance)
         log.write("\n-----\n")
@@ -112,10 +112,10 @@ def handle_invalid(node, schema):
     global nb_instances_failed
 
     instance = node.prop("dtd")
-    if instance == None:
+    if instance is None:
         instance = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    instance = instance + child.serialize()
 	child = child.next
@@ -127,7 +127,7 @@ def handle_invalid(node, schema):
     except:
         doc = None
 
-    if doc == None:
+    if doc is None:
         log.write("\nStrange: failed to parse incorrect instance:\n-----\n")
 	log.write(instance)
         log.write("\n-----\n")
@@ -167,7 +167,7 @@ def handle_correct(node):
 
     schema = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
 	child = child.next
@@ -177,7 +177,7 @@ def handle_correct(node):
 	rngs = rngp.relaxNGParse()
     except:
         rngs = None
-    if rngs == None:
+    if rngs is None:
         log.write("\nFailed to compile correct schema:\n-----\n")
 	log.write(schema)
         log.write("\n-----\n")
@@ -193,7 +193,7 @@ def handle_incorrect(node):
 
     schema = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    schema = schema + child.serialize()
 	child = child.next
@@ -203,7 +203,7 @@ def handle_incorrect(node):
 	rngs = rngp.relaxNGParse()
     except:
         rngs = None
-    if rngs != None:
+    if rngs is not None:
         log.write("\nFailed to detect schema error in:\n-----\n")
 	log.write(schema)
         log.write("\n-----\n")
@@ -226,17 +226,17 @@ def handle_resource(node, dir):
     except:
         name = None
 
-    if name == None or name == '':
+    if name is None or name == '':
         log.write("resource has no name")
 	return;
         
-    if dir != None:
+    if dir is not None:
 #        name = libxml2.buildURI(name, dir)
         name = dir + '/' + name
 
     res = ""
     child = node.children
-    while child != None:
+    while child is not None:
         if child.type != 'text':
 	    res = res + child.serialize()
 	child = child.next
@@ -251,11 +251,11 @@ def handle_dir(node, dir):
     except:
         name = None
 
-    if name == None or name == '':
+    if name is None or name == '':
         log.write("resource has no name")
 	return;
         
-    if dir != None:
+    if dir is not None:
 #        name = libxml2.buildURI(name, dir)
         name = dir + '/' + name
 
@@ -308,7 +308,7 @@ def handle_testCase(node):
     valids = node.xpathEval('valid')
     invalids = node.xpathEval('invalid')
     nb_instances_tests = nb_instances_tests + len(valids) + len(invalids)
-    if schema != None:
+    if schema is not None:
         for valid in valids:
 	    handle_valid(valid, schema)
         for invalid in invalids:

--- a/third_party/libxml/src/gentest.py
+++ b/third_party/libxml/src/gentest.py
@@ -501,7 +501,7 @@ test.write("/* CUT HERE: everything below that line is generated */\n")
 # Open the input API description
 #
 doc = libxml2.readFile(srcPref + 'doc/libxml2-api.xml', None, 0)
-if doc == None:
+if doc is None:
     print "Failed to load doc/libxml2-api.xml"
     sys.exit(1)
 ctxt = doc.xpathNewContext()
@@ -542,7 +542,7 @@ for enum in enums:
     #
     # Skip any enums which are not in our filtered lists
     #
-    if (name == None) or ((name not in argtypes) and (name not in rettypes)):
+    if (name is None) or ((name not in argtypes) and (name not in rettypes)):
         continue;
     define = 0
 
@@ -552,7 +552,7 @@ for enum in enums:
 	vals = []
 	for value in values:
 	    vname = value.xpathEval('string(@name)')
-	    if vname == None:
+	    if vname is None:
 		continue;
 	    i = i + 1
 	    if i >= 5:
@@ -598,7 +598,7 @@ static void des_%s(int no ATTRIBUTE_UNUSED, %s val ATTRIBUTE_UNUSED, int nr ATTR
 headers = ctxt.xpathEval("/api/files/file")
 for file in headers:
     name = file.xpathEval('string(@name)')
-    if (name == None) or (name == ''):
+    if (name is None) or (name == ''):
         continue
 
     #
@@ -752,7 +752,7 @@ test_%s(void) {
 	test.write("    int mem_base;\n");
 
     # Declare the return value
-    if t_ret != None:
+    if t_ret is not None:
         test.write("    %s ret_val;\n" % (t_ret[1]))
 
     # Declare the arguments
@@ -785,7 +785,7 @@ test_%s(void) {
     # do the call, and clanup the result
     if extra_pre_call.has_key(name):
 	test.write("        %s\n"% (extra_pre_call[name]))
-    if t_ret != None:
+    if t_ret is not None:
 	test.write("\n        ret_val = %s(" % (name))
 	need = 0
 	for arg in t_args:

--- a/third_party/libxml/src/regressions.py
+++ b/third_party/libxml/src/regressions.py
@@ -182,7 +182,7 @@ def runOneTest(testDescription, filename, inbase, errbase):
             for l in outfile:
                 print l
             print 'trouble with %s' % cmd
-    if experr != None:
+    if experr is not None:
         ret = compFiles(errfile, experr, inbase, 'test/')
         if ret != 0:
             print 'trouble with %s' % cmd

--- a/third_party/ply/yacc.py
+++ b/third_party/ply/yacc.py
@@ -486,7 +486,7 @@ class LRParser:
                     # --! DEBUG
                     return result
 
-            if t == None:
+            if t is None:
 
                 # --! DEBUG
                 debug.error('Error  : %s',
@@ -764,7 +764,7 @@ class LRParser:
                     n = symstack[-1]
                     return getattr(n,"value",None)
 
-            if t == None:
+            if t is None:
 
                 # We have some kind of parsing error here.  To handle
                 # this, we are going to push the current token onto
@@ -1019,7 +1019,7 @@ class LRParser:
                     n = symstack[-1]
                     return getattr(n,"value",None)
 
-            if t == None:
+            if t is None:
 
                 # We have some kind of parsing error here.  To handle
                 # this, we are going to push the current token onto

--- a/third_party/protobuf/python/setup.py
+++ b/third_party/protobuf/python/setup.py
@@ -55,7 +55,7 @@ def generate_proto(source):
       sys.stderr.write("Can't find required file: %s\n" % source)
       sys.exit(-1)
 
-    if protoc == None:
+    if protoc is None:
       sys.stderr.write(
           "protoc is not installed nor found in ../src.  Please compile it "
           "or install the binary package.\n")

--- a/third_party/re2/lib/codereview/codereview.py
+++ b/third_party/re2/lib/codereview/codereview.py
@@ -424,9 +424,9 @@ def ParseCL(text, name):
 		if line != '' and line[0] == '#':
 			continue
 		if line == '' or line[0] == ' ' or line[0] == '\t':
-			if sname == None and line != '':
+			if sname is None and line != '':
 				return None, lineno, 'text outside section'
-			if sname != None:
+			if sname is not None:
 				sections[sname] += line + '\n'
 			continue
 		p = line.find(':')
@@ -611,7 +611,7 @@ def RepoDir(ui, repo):
 # Find (or make) code review directory.  On error, ui.warn and return None
 def CodeReviewDir(ui, repo):
 	dir = RepoDir(ui, repo)
-	if dir == None:
+	if dir is None:
 		return None
 	dir += '/.hg/codereview/'
 	if not os.path.isdir(dir):
@@ -643,7 +643,7 @@ def StripCommon(text):
 			continue
 		line = TabsToSpaces(line)
 		white = line[:len(line)-len(line.lstrip())]
-		if ws == None:
+		if ws is None:
 			ws = white
 		else:
 			common = ''
@@ -653,7 +653,7 @@ def StripCommon(text):
 			ws = common
 		if ws == '':
 			break
-	if ws == None:
+	if ws is None:
 		return text
 	t = ''
 	for line in text.split('\n'):
@@ -2456,7 +2456,7 @@ def MySend1(request_path, payload=None,
 	# TODO: Don't require authentication.  Let the server say
 	# whether it is necessary.
 	global rpc
-	if rpc == None:
+	if rpc is None:
 		rpc = GetRpcServer(upload_options)
 	self = rpc
 	if not self.authenticated and force_auth:
@@ -3311,9 +3311,9 @@ class VersionControlSystem(object):
 				base_content = None
 				file_id_str = file_id_str[file_id_str.rfind("_") + 1:]
 			file_id = int(file_id_str)
-			if base_content != None:
+			if base_content is not None:
 				StartUploadFile(filename, file_id, base_content, is_binary, status, True)
-			if new_content != None:
+			if new_content is not None:
 				StartUploadFile(filename, file_id, new_content, is_binary, status, False)
 		WaitForUploads()
 

--- a/third_party/re2/re2/testing/unicode_test.py
+++ b/third_party/re2/re2/testing/unicode_test.py
@@ -181,7 +181,7 @@ class CategoriesTest(googletest.TestCase):
           # prefer category Nd over N
           if len(category) > 1:
             return category
-          if short == None:
+          if short is None:
             short = category
     return short
 

--- a/tools/idl_parser/idl_node.py
+++ b/tools/idl_parser/idl_node.py
@@ -156,7 +156,7 @@ class IDLNode(object):
             self.out.append(tab + '  PROPERTIES')
             self.out.extend(proplist)
 
-    if filter_nodes == None:
+    if filter_nodes is None:
       filter_nodes = ['Comment', 'Copyright']
 
     search = DumpTreeSearch(accept_props)

--- a/tools/valgrind/chrome_tests.py
+++ b/tools/valgrind/chrome_tests.py
@@ -115,7 +115,7 @@ class ChromeTests:
       cmd += self._options.valgrind_tool_flags.split(" ")
     if self._options.keep_logs:
       cmd += ["--keep_logs"]
-    if valgrind_test_args != None:
+    if valgrind_test_args is not None:
       for arg in valgrind_test_args:
         cmd.append(arg)
     if exe:

--- a/tools/valgrind/memcheck_analyze.py
+++ b/tools/valgrind/memcheck_analyze.py
@@ -105,7 +105,7 @@ def gatherFrames(node, source_dir):
     frames += [frame_dict]
 
     global TheAddressTable
-    if TheAddressTable != None and frame_dict[SRC_LINE] == "":
+    if TheAddressTable is not None and frame_dict[SRC_LINE] == "":
       # Try using gdb
       TheAddressTable.Add(frame_dict[OBJECT_FILE],
                           frame_dict[INSTRUCTION_POINTER])
@@ -219,7 +219,7 @@ class ValgrindError:
         description = None
         stack = None
         frames = None
-      elif description and node.localName != None:
+      elif description and node.localName is not None:
         # The lastest description has no stack, e.g. "Address 0x28 is unknown"
         self._additional.append(description)
         description = None
@@ -257,11 +257,11 @@ class ValgrindError:
         i = i + 1
 
         global TheAddressTable
-        if TheAddressTable != None and frame[SRC_FILE_DIR] == "":
+        if TheAddressTable is not None and frame[SRC_FILE_DIR] == "":
            # Try using gdb
            foo = TheAddressTable.GetFileLine(frame[OBJECT_FILE],
                                              frame[INSTRUCTION_POINTER])
-           if foo[0] != None:
+           if foo[0] is not None:
              output += (" (" + foo[0] + ":" + foo[1] + ")")
         elif frame[SRC_FILE_DIR] != "":
           output += (" (" + frame[SRC_FILE_DIR] + "/" + frame[SRC_FILE_NAME] +
@@ -273,7 +273,7 @@ class ValgrindError:
     for additional in self._additional:
       output += additional + "\n"
 
-    assert self._suppression != None, "Your Valgrind doesn't generate " \
+    assert self._suppression is not None, "Your Valgrind doesn't generate " \
                                       "suppressions - is it too old?"
 
     if self._testcase:
@@ -462,7 +462,7 @@ class MemcheckAnalyzer:
     suppcounts = defaultdict(int)
     badfiles = set()
 
-    if self._analyze_start_time == None:
+    if self._analyze_start_time is None:
       self._analyze_start_time = time.time()
     start_time = self._analyze_start_time
 
@@ -531,7 +531,7 @@ class MemcheckAnalyzer:
               logging.warn("> %s" % context_data)
           context_file.close()
           continue
-        if TheAddressTable != None:
+        if TheAddressTable is not None:
           load_objs = parsed_file.getElementsByTagName("load_obj")
           for load_obj in load_objs:
             obj = getTextOf(load_obj, "obj")
@@ -590,7 +590,7 @@ class MemcheckAnalyzer:
     if cur_report_errors:
       logging.error("FAIL! There were %s errors: " % len(cur_report_errors))
 
-      if TheAddressTable != None:
+      if TheAddressTable is not None:
         TheAddressTable.ResolveAll()
 
       for error in cur_report_errors:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:mojo?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:mojo?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
